### PR TITLE
📝 Update output formatting of "kubectl get deploy"-commands

### DIFF
--- a/01-pods-deployments.md
+++ b/01-pods-deployments.md
@@ -171,9 +171,9 @@ Verify that the deployment is created:
 
 ```shell
 $ kubectl get deployments
-NAME        DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-multitool   1         1         1            1           59m
-nginx       1         1         1            1           36s
+NAME        READY   UP-TO-DATE   AVAILABLE   AGE
+multitool   1/1     1            1           59m
+nginx       1/1     1            1           36s
 ```
 
 Check if the pods are running:

--- a/02-service-discovery-and-loadbalancing.md
+++ b/02-service-discovery-and-loadbalancing.md
@@ -214,9 +214,9 @@ Check the deployment and pods:
 
 ```shell
 $ kubectl get deployments
-NAME        DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-multitool   1         1         1            1           24m
-nginx       4         4         4            4           34m
+NAME        READY   UP-TO-DATE   AVAILABLE   AGE
+multitool   1/1     1            1           24m
+nginx       4/4     4            4           34m
 ```
 
 ```shell
@@ -229,7 +229,7 @@ nginx-569477d6d8-s6lsn       1/1       Running   0          34s
 nginx-569477d6d8-v8srx       1/1       Running   0          35s
 ```
 
-**Notice:** The nginx deployment says Desired=4, Current=4, Available=4. And the pods also show the same. There are now 4 nginx pods running; one of them was already running (being older), and the other three are started just now.
+**Notice:** The nginx deployment says Ready=4/4, Up-to-date=4, Available=4. And the pods also show the same. There are now 4 nginx pods running; one of them was already running (being older), and the other three are started just now.
 
 You can also scale down! - e.g. to 2:
 


### PR DESCRIPTION
New output formatting of the `kubectl get deploy` command now formats its output similar to `kubectl get pods` where the DESIRED and CURRENT columns are contracted into READY.

In case it's relevant, this is the `kubectl` version I'm running:
```shell
❯ kubectl version --short
Client Version: v1.17.2
Server Version: v1.17.2
```