### PR TITLE
👽 Rewrite deprecated "kubectl run" commands

### DIFF
--- a/06-ingress-nginx.md
+++ b/06-ingress-nginx.md
@@ -6,7 +6,8 @@ To enable an ingress object, we need an ingress controller. In this example we w
 
 To get started with NGINX ingress, we (re)deploy an app of our choice: 
 ```
-kubectl run ingress-test --image=<your-image> --replicas=3
+kubectl create deployment ingress-test --image=<your-image>
+kubectl scale deployment ingress-test --replicas=3
 kubectl expose deployment ingress-test --port=<your-port>
 ```
 

--- a/06-ingress-traefik.md
+++ b/06-ingress-traefik.md
@@ -321,7 +321,8 @@ So the magic here is that:
 Let's try with a different container. Deploy any given image and expose a service for it. 
 
 ```
-kubectl run ingress-test --image=<your-image> --replicas=3
+kubectl create deployment ingress-test --image=<your-image>
+kubectl scale deployment ingress-test  --replicas=3
 kubectl expose deployment ingress-test --port=<your-port>
 ```
 


### PR DESCRIPTION
Creating deployments with the `kubectl run` command is deprecated:
```bash
❯ kubectl run ingress-test --image=nginx --replicas=3
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.
deployment.apps/ingress-test created
```